### PR TITLE
adiciona ferramenta de data e hora

### DIFF
--- a/src/Melissa/Melissa.Core/AiTools/Time/TimeOllamaTools.cs
+++ b/src/Melissa/Melissa.Core/AiTools/Time/TimeOllamaTools.cs
@@ -1,0 +1,17 @@
+using System.Globalization;
+using OllamaSharp;
+
+namespace Melissa.Core.AiTools.Time;
+
+public class TimeOllamaTools
+{
+    /// <summary>
+    /// Retorna a data e hora atual no formato brasileiro.
+    /// </summary>
+    /// <returns></returns>
+    [OllamaTool]
+    public static string GetCurrentDateTime()
+    {
+        return DateTime.Now.ToString("F", new CultureInfo("pt-BR"));
+    }
+}

--- a/src/Melissa/Melissa.Core/Assistants/Melissa.cs
+++ b/src/Melissa/Melissa.Core/Assistants/Melissa.cs
@@ -1,4 +1,5 @@
 using Melissa.Core.AiTools.Holidays;
+using Melissa.Core.AiTools.Time;
 using Melissa.Core.AiTools.Weather;
 using Melissa.Core.Chats;
 
@@ -18,7 +19,8 @@ public class Melissa : Assistant
             .WithAdicionalDescription("Responda de forma breve, como se estivesse falando oralmente, usando frases curtas e diretas.")
             //.WithTool(new GetWeatherTool());
             .WithTool(new GetBrazilianHolidaysTool())
-            .WithTool(new GetHolidayDateByNameTool());
+            .WithTool(new GetHolidayDateByNameTool())
+            .WithTool(new GetCurrentDateTimeTool());
         Chat = chatBuilder.Build().Result;
     }
 

--- a/src/Melissa/Melissa.Core/Melissa.Core.csproj
+++ b/src/Melissa/Melissa.Core/Melissa.Core.csproj
@@ -19,5 +19,4 @@
         <PackageReference Include="OllamaSharp" Version="5.1.13" />
     </ItemGroup>
 
-
 </Project>


### PR DESCRIPTION
## O que foi feito

- [x] Reconhece data
- [x] Reconhece hora

## Evidência

O print mostra que a Assistente ainda responde perguntas genéricas, mas também é capaz de utilizar a nova ferramenta sobre data e hora.

![image](https://github.com/user-attachments/assets/a1282be6-a3a0-4bb8-928e-0503fe451ed8)