### PR TITLE
Feat/programacao defensiva

### DIFF
--- a/src/Melissa/Melissa.Core/Assistants/Assistant.cs
+++ b/src/Melissa/Melissa.Core/Assistants/Assistant.cs
@@ -1,9 +1,12 @@
 using Melissa.Core.Chats;
+using Serilog;
 
 namespace Melissa.Core.Assistants;
 
 public abstract class Assistant
 {
+    public abstract string Name { get; }
+    
     protected IChat Chat = null!;
 
     protected Assistant(IChatBuilder chatBuilder)
@@ -12,7 +15,15 @@ public abstract class Assistant
 
     public async Task<bool> CanUse()
     {
-        return await Chat.IsChatReady();
+        try
+        {
+            return await Chat.IsChatReady();
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "{assistantName} não está disponível.", Name);
+            return false;
+        }
     }
     
     public virtual IAsyncEnumerable<string> Ask(Question question, CancellationToken cancellationToken = default)

--- a/src/Melissa/Melissa.Core/Assistants/Assistant.cs
+++ b/src/Melissa/Melissa.Core/Assistants/Assistant.cs
@@ -8,21 +8,23 @@ public abstract class Assistant
     public abstract string Name { get; }
     
     protected IChat Chat = null!;
+    public abstract string UnavailabilityMessage { get; }
 
     protected Assistant(IChatBuilder chatBuilder)
     {
     }
 
-    public async Task<bool> CanUse()
+    public async Task<(bool isAvailable, string statusMessage)> CanUse()
     {
         try
         {
-            return await Chat.IsChatReady();
+            var canUse = await Chat.IsChatReady();
+            return (canUse, string.Empty);
         }
         catch (Exception e)
         {
             Log.Error(e, "{assistantName} não está disponível.", Name);
-            return false;
+            return (false, UnavailabilityMessage);
         }
     }
     

--- a/src/Melissa/Melissa.Core/Assistants/AssistantFactory.cs
+++ b/src/Melissa/Melissa.Core/Assistants/AssistantFactory.cs
@@ -1,0 +1,39 @@
+using Melissa.Core.Chats;
+using Melissa.Core.Chats.Ollama;
+using Serilog;
+
+namespace Melissa.Core.Assistants;
+
+/// <summary>
+/// Fábrica para criação de Assistentes
+/// </summary>
+public class AssistantFactory
+{
+    private readonly IChatBuilder _builder = new OllamaChatBuilder();
+    
+    /// <summary>
+    /// Cria Melissa. Possui sistema de retry em caso de erro. 
+    /// </summary>
+    /// <param name="timeBetweenRetries">Tempo entre as tentativas</param>
+    /// <returns></returns>
+    public async Task<Melissa> TryCreateMelissa(TimeSpan timeBetweenRetries)
+    {
+        var n = 1;
+        
+        while (true)
+        {
+            try
+            {
+                var melissa = new Melissa(_builder);
+                Log.Information("Melissa iniciada");
+                return melissa;
+            }
+            catch (Exception)
+            {
+                Log.Warning("Tentativa: {n}. Erro ao iniciar Melissa", n);
+                n++;
+                await Task.Delay(timeBetweenRetries);
+            }
+        }
+    }
+}

--- a/src/Melissa/Melissa.Core/Assistants/Melissa.cs
+++ b/src/Melissa/Melissa.Core/Assistants/Melissa.cs
@@ -8,6 +8,7 @@ namespace Melissa.Core.Assistants;
 public class Melissa : Assistant
 {
     public sealed override string Name => nameof(Melissa);
+    public sealed override string UnavailabilityMessage => "Desculpe, parece que não consigo te responder no momento. Por favor, confira se o Ollama está em execução.";
     
     public Melissa(IChatBuilder chatBuilder) : base(chatBuilder)
     {

--- a/src/Melissa/Melissa.Core/Assistants/Melissa.cs
+++ b/src/Melissa/Melissa.Core/Assistants/Melissa.cs
@@ -7,17 +7,21 @@ namespace Melissa.Core.Assistants;
 
 public class Melissa : Assistant
 {
+    public sealed override string Name => nameof(Melissa);
+    
     public Melissa(IChatBuilder chatBuilder) : base(chatBuilder)
     {
-        var currentDate = DateTime.Now.Date;
         chatBuilder
             .WithModelName(ModelName.Llama32_3B)
-            .WithAssistantName("Melissa")
-            .WithPurposeDescription("""
-                                    Ser uma assistente pessoal inteligente chamada Melissa, capaz de responder perguntas gerais e usar ferramentas externas quando necessário.
-                                    Use ferramentas quando a pergunta envolver informações específicas como datas de feriados no Brasil.
-                                    """)
-            .WithAdicionalDescription($"Responda de forma breve, como se estivesse falando oralmente, usando frases curtas e diretas. O dia atual é {currentDate}")
+            .WithAssistantName(Name)
+            .WithPurposeDescription($"Ser uma assistente pessoal inteligente chamada {Name}, capaz de responder perguntas gerais e usar ferramentas específicas quando necessário.")
+            .WithAdicionalDescription("Sempre responda seu propósito quando for perguntado ou solicitado que se apresente.")
+            .WithAdicionalDescription("Responda de forma breve, como se estivesse falando oralmente, usando frases curtas, diretas e sempre em português do Brasil.")
+            .WithAdicionalDescription("NÃO utilize qualquer formatação em suas respostas.")
+            .WithAdicionalDescription("Se o usuário pedir informações sobre feriados, utilize sua ferramenta GetBrazilianHolidaysTool.")
+            .WithAdicionalDescription("Se o usuário perguntar sobre uma data específica, utilize sua ferramenta GetHolidayDateByNameTool.")
+            .WithAdicionalDescription("Se o usuário precisar saber sobre o dia ou a hora atual, utilize sua ferramenta GetCurrentDateTimeTool.")
+            .WithAdicionalDescription("Sempre utilize sua ferramenta GetCurrentDateTimeTool internamente para melhorar suas respostas.")
             .WithTool(new GetWeatherByLocationTool())
             .WithTool(new GetBrazilianHolidaysTool())
             .WithTool(new GetHolidayDateByNameTool())

--- a/src/Melissa/Melissa.Core/Melissa.Core.csproj
+++ b/src/Melissa/Melissa.Core/Melissa.Core.csproj
@@ -17,6 +17,7 @@
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.4" />
         <PackageReference Include="OllamaSharp" Version="5.1.13" />
+        <PackageReference Include="Serilog" Version="4.2.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Melissa/Melissa.WebServer/Program.cs
+++ b/src/Melissa/Melissa.WebServer/Program.cs
@@ -1,4 +1,4 @@
-using Melissa.Core.Chats.Ollama;
+using Melissa.Core.Assistants;
 using Melissa.Core.ExternalData;
 using Melissa.WebServer;
 using Serilog;
@@ -10,7 +10,10 @@ Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
     .CreateLogger();
 
-var melissa = new Melissa.Core.Assistants.Melissa(new OllamaChatBuilder());
+var assistantFactory = new AssistantFactory();
+var melissa = await assistantFactory.TryCreateMelissa(TimeSpan.FromSeconds(10));
+
+// A assistente precisa ser um Singleton para ser persistido o contexto da conversa
 builder.Services.AddSingleton(melissa);
 
 var app = builder.Build();


### PR DESCRIPTION
## O que foi feito

- [x] Melhoradas instruções para a Melissa
- [x] Adicionada dependência do pacote _Serilog_ no projeto `Melissa.Core`
- [x] Corrigida implementação do método `CanUse( )` da classe  `Assistant`
- [x] Implementada verificação de estado da assistente antes de cada input para a Melissa
- [x] Implementado retry na criação da Melissa na inicialização do projeto `Melissa.WebServer` 

## Evidências

### Novas instruções
As descrições foram trabalhadas de forma imperativa e utilizando como guia os [prompts vazados do Chat GPT 4o](https://github.com/jujumilk3/leaked-system-prompts/tree/main).

- Ferramentas descritas individualmente
- Remoção de formatação de texto (Ex: asteriscos, bullet points, etc.)
- Garantia de resposta em Pt-BR
- Garantia de apresentação correta das informações sobre a assistente

TODO: @Victorrj22 quando corrigir a função de clima/previsão do tempo, adicionar a descrição conforme achar melhor.

![image](https://github.com/user-attachments/assets/a96ac25d-b330-4a43-9727-9aa4c32e22d5)

### Inicialização do servidor web sem Ollama disponível
Dessa forma, a Melissa não pode ser criada. Anteriormente, uma exceção era lançada e o servidor encerrado.

Agora, o sistema faz uma nova tentativa a cada 10 segundos de criar a Melissa. Uma vez que as necessidades para a criação forem supridas, é notificado o sucesso e o sistema prossegue a inicialização de forma saudável.

Para encapsular o algoritmo de retry, foi criado uma classe Factory.

https://github.com/user-attachments/assets/d7f9d99c-1eb5-44ee-ac9c-b40184813298

### Indisponibilidade da Melissa após inicialização do servidor

**Aqui há dois casos:**
1. Melissa ficou indisponível antes de receber o prompt do usuário (vídeo ficou sem áudio, mas da para verificar pelo log)

https://github.com/user-attachments/assets/f3a74c1b-8c9e-4b48-93f1-fd632d8d8ecd

2. Melissa ficou indisponível enquanto respondia o prompt do usuário

https://github.com/user-attachments/assets/6e8c58e2-0912-428e-9775-9e48da622175


